### PR TITLE
fix for 'directory not empty' on build_commandpost_testing.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build:
 	mkdir -p build
 
 clean:
-	rm -rf build
+	rm -rf build/
 	rm -rf LuaSkin.framework
 
 clean-docs:


### PR DESCRIPTION
When running the build script on my system I noticed running it again without blowing away the directories myself caused

`rm -rf build`

to fail. This fixed it.